### PR TITLE
Datastore API Get Requests and Query String

### DIFF
--- a/domain-get-legacy/function.json
+++ b/domain-get-legacy/function.json
@@ -1,12 +1,12 @@
 {
   "bindings": [
     {
-      "route": "v1/domains/subdomains/{id}",
+      "route": "domains/get/{id}",
       "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["get"]
+      "methods": ["post"]
     },
     {
       "type": "http",
@@ -14,5 +14,5 @@
       "name": "res"
     }
   ],
-  "scriptFile": "../dist/domain-get-subdomains/index.js"
+  "scriptFile": "../dist/domain-get-legacy/index.js"
 }

--- a/domain-get-legacy/index.ts
+++ b/domain-get-legacy/index.ts
@@ -1,0 +1,15 @@
+import { AzureFunction, Context, HttpRequest } from "@azure/functions";
+import {
+  doServiceOperation,
+  getDomain,
+} from "../src/services/legacyDomainService";
+
+const httpTrigger: AzureFunction = async function (
+  context: Context,
+  req: HttpRequest
+): Promise<void> {
+  context.log("HTTP trigger function processed a request.");
+  await doServiceOperation(getDomain, context, req);
+};
+
+export default httpTrigger;

--- a/domain-get-subdomains-legacy/function.json
+++ b/domain-get-subdomains-legacy/function.json
@@ -1,12 +1,12 @@
 {
   "bindings": [
     {
-      "route": "v1/domains/subdomains/{id}",
+      "route": "domains/subdomains/{id}",
       "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["get"]
+      "methods": ["post"]
     },
     {
       "type": "http",
@@ -14,5 +14,5 @@
       "name": "res"
     }
   ],
-  "scriptFile": "../dist/domain-get-subdomains/index.js"
+  "scriptFile": "../dist/domain-get-subdomains-legacy/index.js"
 }

--- a/domain-get-subdomains-legacy/index.ts
+++ b/domain-get-subdomains-legacy/index.ts
@@ -1,0 +1,14 @@
+import { AzureFunction, Context, HttpRequest } from "@azure/functions";
+import {
+  doServiceOperation,
+  getSubdomains,
+} from "../src/services/legacyDomainService";
+
+const httpTrigger: AzureFunction = async function (
+  context: Context,
+  req: HttpRequest
+): Promise<void> {
+  await doServiceOperation(getSubdomains, context, req);
+};
+
+export default httpTrigger;

--- a/domain-get-subdomains/index.ts
+++ b/domain-get-subdomains/index.ts
@@ -1,11 +1,34 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import { doServiceOperation, getSubdomains } from "../src/services/domainService";
+import { DomainId } from "@zero-tech/data-store-core";
+import { getMongoDomainService } from "../src/helpers";
+import { getDomainFindOptionsFromQuery } from "../src/helpers/domainFindOptionsHelper";
+import { validateDomainId } from "../src/schemas";
+import { createHTTPResponse } from "../src/helpers/createHTTPResponse";
+import { createErrorResponse } from "../src/helpers/createErrorResponse";
 
 const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest
 ): Promise<void> {
-  await doServiceOperation(getSubdomains, context, req);
+  try {
+    const domainId: DomainId = req.params.id;
+    if (!validateDomainId(domainId)) {
+      context.res = createHTTPResponse(400, validateDomainId.errors);
+      return;
+    }
+
+    const findOptions = getDomainFindOptionsFromQuery(req);
+    const domainService = await getMongoDomainService();
+    const response = await domainService.getSubdomains(
+      req.params.id,
+      findOptions
+    );
+    context.res = {
+      body: response,
+    };
+  } catch (err) {
+    context.res = createErrorResponse(err, context);
+  }
 };
 
 export default httpTrigger;

--- a/domain-get/function.json
+++ b/domain-get/function.json
@@ -1,12 +1,12 @@
 {
   "bindings": [
     {
-      "route": "domains/get/{id}",
+      "route": "v1/domains/get/{id}",
       "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["post"]
+      "methods": ["get"]
     },
     {
       "type": "http",

--- a/domain-get/index.ts
+++ b/domain-get/index.ts
@@ -1,12 +1,31 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import { doServiceOperation, getDomain } from "../src/services/domainService";
-
+import { DomainId } from "@zero-tech/data-store-core";
+import { getMongoDomainService } from "../src/helpers";
+import { createErrorResponse } from "../src/helpers/createErrorResponse";
+import { createHTTPResponse } from "../src/helpers/createHTTPResponse";
+import { getDomainFindOptionsFromQuery } from "../src/helpers/domainFindOptionsHelper";
+import { validateDomainId } from "../src/schemas";
 const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest
 ): Promise<void> {
   context.log("HTTP trigger function processed a request.");
-  await doServiceOperation(getDomain, context, req);
+  try {
+    const domainId: DomainId = req.params.id;
+    if (!validateDomainId(domainId)) {
+      context.res = createHTTPResponse(400, validateDomainId.errors);
+      return;
+    }
+
+    let findOptions = getDomainFindOptionsFromQuery(req);
+    const domainService = await getMongoDomainService();
+    const response = await domainService.getDomain(req.params.id, findOptions);
+    context.res = {
+      body: response,
+    };
+  } catch (err) {
+    context.res = createErrorResponse(err, context);
+  }
 };
 
 export default httpTrigger;

--- a/domain-search-by-name-legacy/function.json
+++ b/domain-search-by-name-legacy/function.json
@@ -1,12 +1,12 @@
 {
   "bindings": [
     {
-      "route": "v1/domains/subdomains/{id}",
+      "route": "domains/search/name/{name}",
       "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["get"]
+      "methods": ["post"]
     },
     {
       "type": "http",
@@ -14,5 +14,5 @@
       "name": "res"
     }
   ],
-  "scriptFile": "../dist/domain-get-subdomains/index.js"
+  "scriptFile": "../dist/domain-search-by-name-legacy/index.js"
 }

--- a/domain-search-by-name-legacy/index.ts
+++ b/domain-search-by-name-legacy/index.ts
@@ -1,0 +1,14 @@
+import { AzureFunction, Context, HttpRequest } from "@azure/functions";
+import {
+  doServiceOperation,
+  searchDomainsByName,
+} from "../src/services/legacyDomainService";
+
+const httpTrigger: AzureFunction = async function (
+  context: Context,
+  req: HttpRequest
+): Promise<void> {
+  await doServiceOperation(searchDomainsByName, context, req);
+};
+
+export default httpTrigger;

--- a/domain-search-by-name/function.json
+++ b/domain-search-by-name/function.json
@@ -1,12 +1,12 @@
 {
   "bindings": [
     {
-      "route": "domains/search/name/{name}",
+      "route": "v1/domains/search/name/{name}",
       "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["post"]
+      "methods": ["get"]
     },
     {
       "type": "http",

--- a/domain-search-by-name/index.ts
+++ b/domain-search-by-name/index.ts
@@ -1,11 +1,27 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import { doServiceOperation, searchDomainsByName } from "../src/services/domainService";
+import { getMongoDomainService } from "../src/helpers";
+import { createErrorResponse } from "../src/helpers/createErrorResponse";
+import { getDomainFindOptionsFromQuery } from "../src/helpers/domainFindOptionsHelper";
 
 const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest
 ): Promise<void> {
-  await doServiceOperation(searchDomainsByName, context, req);
+  try {
+    const domainName: string = req.params.name;
+
+    let findOptions = getDomainFindOptionsFromQuery(req);
+    const domainService = await getMongoDomainService();
+    const response = await domainService.searchDomainsByName(
+      domainName,
+      findOptions
+    );
+    context.res = {
+      body: response,
+    };
+  } catch (err) {
+    context.res = createErrorResponse(err, context);
+  }
 };
 
 export default httpTrigger;

--- a/domain-search-by-owner-legacy/function.json
+++ b/domain-search-by-owner-legacy/function.json
@@ -1,12 +1,12 @@
 {
   "bindings": [
     {
-      "route": "v1/domains/subdomains/{id}",
+      "route": "domains/search/owner/{address}",
       "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["get"]
+      "methods": ["post"]
     },
     {
       "type": "http",
@@ -14,5 +14,5 @@
       "name": "res"
     }
   ],
-  "scriptFile": "../dist/domain-get-subdomains/index.js"
+  "scriptFile": "../dist/domain-search-by-owner-legacy/index.js"
 }

--- a/domain-search-by-owner-legacy/index.ts
+++ b/domain-search-by-owner-legacy/index.ts
@@ -1,0 +1,14 @@
+import { AzureFunction, Context, HttpRequest } from "@azure/functions";
+import {
+  doServiceOperation,
+  searchDomainsByOwner,
+} from "../src/services/legacyDomainService";
+
+const httpTrigger: AzureFunction = async function (
+  context: Context,
+  req: HttpRequest
+): Promise<void> {
+  await doServiceOperation(searchDomainsByOwner, context, req);
+};
+
+export default httpTrigger;

--- a/domain-search-by-owner/function.json
+++ b/domain-search-by-owner/function.json
@@ -1,12 +1,12 @@
 {
   "bindings": [
     {
-      "route": "domains/search/owner/{address}",
+      "route": "v1/domains/search/owner/{address}",
       "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["post"]
+      "methods": ["get"]
     },
     {
       "type": "http",

--- a/domain-search-by-owner/index.ts
+++ b/domain-search-by-owner/index.ts
@@ -1,11 +1,34 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import { doServiceOperation, searchDomainsByOwner } from "../src/services/domainService";
+import { Address } from "@zero-tech/data-store-core";
+import { getMongoDomainService } from "../src/helpers";
+import { createErrorResponse } from "../src/helpers/createErrorResponse";
+import { createHTTPResponse } from "../src/helpers/createHTTPResponse";
+import { getDomainFindOptionsFromQuery } from "../src/helpers/domainFindOptionsHelper";
+import { validateAddress } from "../src/schemas";
 
 const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest
 ): Promise<void> {
-  await doServiceOperation(searchDomainsByOwner, context, req);
+  try {
+    const ownerAddress: Address = req.params.address;
+    if (!validateAddress(ownerAddress)) {
+      context.res = createHTTPResponse(400, validateAddress.errors);
+      return;
+    }
+
+    let findOptions = getDomainFindOptionsFromQuery(req);
+    const domainService = await getMongoDomainService();
+    const response = await domainService.searchDomainsByOwner(
+      ownerAddress,
+      findOptions
+    );
+    context.res = {
+      body: response,
+    };
+  } catch (err) {
+    context.res = createErrorResponse(err, context);
+  }
 };
 
 export default httpTrigger;

--- a/domains-legacy/function.json
+++ b/domains-legacy/function.json
@@ -1,12 +1,12 @@
 {
   "bindings": [
     {
-      "route": "v1/domains/subdomains/{id}",
+      "route": "domains/list",
       "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["get"]
+      "methods": ["post"]
     },
     {
       "type": "http",
@@ -14,5 +14,5 @@
       "name": "res"
     }
   ],
-  "scriptFile": "../dist/domain-get-subdomains/index.js"
+  "scriptFile": "../dist/domains-legacy/index.js"
 }

--- a/domains-legacy/index.ts
+++ b/domains-legacy/index.ts
@@ -1,0 +1,14 @@
+import { AzureFunction, Context, HttpRequest } from "@azure/functions";
+import {
+  doServiceOperation,
+  listDomains,
+} from "../src/services/legacyDomainService";
+
+const httpTrigger: AzureFunction = async function (
+  context: Context,
+  req: HttpRequest
+): Promise<void> {
+  await doServiceOperation(listDomains, context, req);
+};
+
+export default httpTrigger;

--- a/domains/function.json
+++ b/domains/function.json
@@ -1,12 +1,12 @@
 {
   "bindings": [
     {
-      "route": "domains/list",
+      "route": "v1/domains/list",
       "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["post"]
+      "methods": ["get"]
     },
     {
       "type": "http",

--- a/domains/index.ts
+++ b/domains/index.ts
@@ -1,11 +1,22 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import { doServiceOperation, listDomains } from "../src/services/domainService";
+import { getMongoDomainService } from "../src/helpers";
+import { createErrorResponse } from "../src/helpers/createErrorResponse";
+import { getDomainFindOptionsFromQuery } from "../src/helpers/domainFindOptionsHelper";
 
 const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest
 ): Promise<void> {
-  await doServiceOperation(listDomains, context, req);
+  try {
+    let findOptions = getDomainFindOptionsFromQuery(req);
+    const domainService = await getMongoDomainService();
+    const response = await domainService.listDomains(findOptions);
+    context.res = {
+      body: response,
+    };
+  } catch (err) {
+    context.res = createErrorResponse(err, context);
+  }
 };
 
 export default httpTrigger;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "data-store-api",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-store-api",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "",
   "scripts": {
     "build": "tsc",

--- a/src/helpers/createErrorResponse.ts
+++ b/src/helpers/createErrorResponse.ts
@@ -1,0 +1,11 @@
+import { Context } from "@azure/functions";
+import { createHTTPResponse } from "./createHTTPResponse";
+
+export function createErrorResponse(err: unknown, context: Context): Object {
+  let body = err;
+  if (err instanceof Error) {
+    body = err.message;
+    context.log(err.name, err.message, err.stack);
+  }
+  return createHTTPResponse(500, body);
+}

--- a/src/helpers/createHTTPResponse.ts
+++ b/src/helpers/createHTTPResponse.ts
@@ -1,0 +1,7 @@
+export function createHTTPResponse(statusCode: number, body: unknown): Object {
+  const response = {
+    status: statusCode,
+    body: body,
+  };
+  return response;
+}

--- a/src/helpers/domainFindOptionsHelper.ts
+++ b/src/helpers/domainFindOptionsHelper.ts
@@ -32,7 +32,7 @@ export function getDomainFindOptionsFromQuery(req: HttpRequest) {
 
 //Converting Number to either 1 or -1
 export function valueToSortDirection(val: DomainSortDirection): Sort {
-  return Number(val) === DomainSortDirection.descending ? -1 : 1;
+  return Number(val) === DomainSortDirection.desc ? -1 : 1;
 }
 
 //Converting Number to either 1 or 0
@@ -88,7 +88,7 @@ export function createSort(req: HttpRequest): DynamicObject<SortDirection> {
           valueToSortDirection(
             DomainSortDirection[
               val.toLowerCase() as keyof typeof DomainSortDirection
-            ] ?? DomainSortDirection.descending
+            ] ?? DomainSortDirection.desc
           )
         );
     }

--- a/src/helpers/domainFindOptionsHelper.ts
+++ b/src/helpers/domainFindOptionsHelper.ts
@@ -1,0 +1,154 @@
+import { HttpRequest } from "@azure/functions";
+import { SortDirection } from "mongodb";
+import { DomainFindOptions } from "@zero-tech/data-store-core";
+import { DomainSortDirection, domainReflectionSchema } from "../types";
+declare type Sort = -1 | 1;
+declare type Projection = 0 | 1;
+interface DynamicObject<T> {
+  [key: string]: T;
+}
+const defaultProjection = ["domainid", "owner", "name"];
+const defaultSort = ["label"];
+const defaultSortDirection: Sort[] = [-1];
+
+/*
+ * Generates a DomainFindOptions object based on query string parameters
+ * @param req - An HttpRequest
+ * @returns  - a DomainFindOptions object, with either default values or values supplied from the query string
+ */
+export function getDomainFindOptionsFromQuery(req: HttpRequest) {
+  //Get variables to project, matching the case insensitive names to case sensitive object names
+  const projection = createProjection(req);
+  const sort = createSort(req);
+
+  let findOptions: DomainFindOptions = {
+    sort: sort,
+    projection: projection,
+    limit: isNaN(+req.query.limit) ? 100 : +req.query.limit, //Setting limit to 0 will return all entries
+    skip: isNaN(+req.query.skip) ? 0 : +req.query.skip,
+  };
+  return findOptions;
+}
+
+//Converting Number to either 1 or -1
+export function valueToSortDirection(val: DomainSortDirection): Sort {
+  return Number(val) === DomainSortDirection.descending ? -1 : 1;
+}
+
+//Converting Number to either 1 or 0
+export function valueToProjection(val: Number): Projection {
+  return Number(val) === 1 ? 1 : 0;
+}
+
+/**
+ * Creates a Projection object, dynamically. If projection is true, and no fields are supplied, it will use the default projection value
+ * @param req - an HttpRequest
+ * @returns - A DomainProjectionOptions object
+ */
+export function createProjection(req: HttpRequest): DynamicObject<Projection> {
+  const projectionInclusion =
+    (req.query?.projection ?? "true").toLowerCase() == "true" ||
+    (req.query?.projection ?? "1") == "1";
+
+  let projectionValues: string[] = [];
+  if (req.query?.fields) {
+    projectionValues = req.query?.fields
+      .split(",")
+      .map((val) => resolveObjectValues(domainReflectionSchema, val));
+  } else if (projectionInclusion) {
+    projectionValues = defaultProjection.map((val) =>
+      resolveObjectValues(domainReflectionSchema, val)
+    );
+  }
+  const projectionObject = createProjectionDynamicObject(
+    projectionValues,
+    valueToProjection(Number(projectionInclusion))
+  );
+  return projectionObject;
+}
+
+/**
+ * Creates a SortObject, dynamically. If no sort directions are supplied, default sort direction is descending
+ * @param req - an HttpRequest
+ * @returns  - a DomainSortOptions object
+ */
+export function createSort(req: HttpRequest): DynamicObject<SortDirection> {
+  let sortValues = defaultSort;
+  let sortDirection = defaultSortDirection;
+  if (req.query) {
+    if (req.query.sort) {
+      sortValues = req.query.sort
+        .split(",")
+        .map((val) => resolveObjectValues(domainReflectionSchema, val));
+    }
+    if (req.query.sortDirection) {
+      sortDirection = req.query?.sortDirection
+        .split(",")
+        .map((val) =>
+          valueToSortDirection(
+            DomainSortDirection[
+              val.toLowerCase() as keyof typeof DomainSortDirection
+            ] ?? DomainSortDirection.descending
+          )
+        );
+    }
+  }
+  const sortObject = createSortDynamicObject(sortValues, sortDirection);
+
+  return sortObject;
+}
+
+/**
+ * Creates a dynamic object with the variables named after the given string and the values set to the projection
+ * @param values - Array of strings to set as the variable names within the object
+ * @param include - The value to set the variables within the object to
+ * @returns
+ */
+export function createProjectionDynamicObject(
+  values: string[],
+  include: Projection
+): DynamicObject<Projection> {
+  let projection: DynamicObject<Projection> = {};
+  values = values.filter((item, index) => {
+    return values.indexOf(item) === index && item !== "";
+  });
+  values.forEach((x) => {
+    projection[x] = include;
+  });
+  return projection;
+}
+/**
+ * Creates a dynamic object with the variables named after the given string and the values set to the sortDirections.
+ * Defaults to -1 when a direction is not supplied
+ * @param sortValues - Array of strings to set as the variable names within the object
+ * @param sortDirections - An array of sort directions to set the variables within the object to
+ * @returns
+ */
+export function createSortDynamicObject(
+  sortValues: string[],
+  sortDirections: SortDirection[]
+): DynamicObject<SortDirection> {
+  let sort: DynamicObject<SortDirection> = {};
+  sortValues = sortValues.filter((item, index) => {
+    return sortValues.indexOf(item) === index;
+  });
+  sortValues.forEach((x, index) => {
+    sort[x] = sortDirections[index] !== undefined ? sortDirections[index] : -1;
+  });
+  return sort;
+}
+
+//Iterates through an object to find matching field names with correct capitalization
+export function resolveObjectValues(
+  object: Object,
+  incomingValue: string
+): string {
+  let match = "";
+  Object.keys(object).some((element) => {
+    if (element.toLowerCase() == incomingValue.toLowerCase()) {
+      match = element;
+      return true; //Break loop
+    }
+  });
+  return match;
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -3,8 +3,9 @@ import { Context } from "@azure/functions";
 import { MongoClient, MongoClientOptions } from "mongodb";
 import { MongoDbService } from "@zero-tech/data-store-core/lib/database/mongo/mongoDbService";
 import * as env from "env-var";
+import { MongoDomainService } from "../services/mongoDomainService";
 
-export async function getConnectedDbClient(context: Context) {
+export async function getConnectedDbClient(context?: Context) {
   const dbUser = env.get("DATABASE_USERNAME").required().asString();
   const dbPassword = env.get("DATABASE_PASSWORD").required().asString();
   const dbUri = env.get("DATABASE_URI").required().asString();
@@ -31,4 +32,10 @@ export async function getConnectedDbClient(context: Context) {
 export function getDatabaseService(dbClient: MongoClient) {
   const dbConnectionInfo = getDbConnectionInfo();
   return MongoDbService.instance(dbClient, dbConnectionInfo);
+}
+
+export async function getMongoDomainService() {
+  const dbClient = await getConnectedDbClient();
+  const dbService = getDatabaseService(dbClient);
+  return new MongoDomainService(dbClient, dbService);
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -176,4 +176,4 @@ export const validateFindOptions = ajv
   .compile(domainFindOptions);
 
 export const validateDomainId = ajv.compile(domainId);
-export const validateBlockchainAddress = ajv.compile(blockchainAddress);
+export const validateAddress = ajv.compile(blockchainAddress);

--- a/src/services/domainService.ts
+++ b/src/services/domainService.ts
@@ -1,177 +1,39 @@
-import { Context, HttpRequest } from "@azure/functions";
-import {
-  Address,
-  DomainFindOptions,
-  DomainId,
-  Maybe,
-} from "@zero-tech/data-store-core";
-import { MongoDbService } from "@zero-tech/data-store-core/lib/database/mongo/mongoDbService";
-import { MongoClient } from "mongodb";
-import { getConnectedDbClient, getDatabaseService } from "../helpers";
-import { validateBlockchainAddress, validateDomainId } from "../schemas";
+import { Domain, DomainFindOptions, Maybe } from "@zero-tech/data-store-core";
+import { DomainsApiResponse } from "../types";
 
-// add try/catch/finally wrapper for 500s
-export async function doServiceOperation(
-  serviceFn: Function,
-  context: Context,
-  request: HttpRequest
-) {
-  let dbClient: Maybe<MongoClient>;
+export abstract class DomainService<T> {
+  dbService: T;
+  constructor(service: T) {
+    this.dbService = service;
+  }
+  abstract listDomains(
+    findOptions: Maybe<DomainFindOptions>
+  ): Promise<DomainsApiResponse>;
+  abstract getDomain(
+    id: string,
+    findOptions: Maybe<DomainFindOptions>
+  ): Promise<Domain>;
+  abstract getSubdomains(
+    id: string,
+    findOptions: Maybe<DomainFindOptions>
+  ): Promise<DomainsApiResponse>;
+  abstract searchDomainsByOwner(
+    address: string,
+    findOptions: Maybe<DomainFindOptions>
+  ): Promise<DomainsApiResponse>;
+  abstract searchDomainsByName(
+    searchTerm: string,
+    findOptions: Maybe<DomainFindOptions>
+  ): Promise<DomainsApiResponse>;
+  abstract doServiceOperation(
+    serviceFn: Function
+  ): Promise<DomainsApiResponse | Domain>;
 
-  try {
-    dbClient = await getConnectedDbClient(context);
-    const dbService: MongoDbService = getDatabaseService(dbClient);
-    await serviceFn(context, request, dbService);
-  } catch (e: any) {
-    const error: Error = {
-      name: e.name ?? "Unknown Internal Server Error",
-      message: e.message ?? "An unexpected server error occured.",
+  domainsToDomainsResponse(domains: Domain[]): DomainsApiResponse {
+    const response: DomainsApiResponse = {
+      numResults: domains.length,
+      results: domains,
     };
-    context.log(e.name, e.message, e.stack);
-
-    context.res = {
-      status: 500,
-      body: `${error.name} \n ${error.message}`,
-    };
-  } finally {
-    if (dbClient) {
-      await dbClient.close();
-    }
+    return response;
   }
-}
-
-export async function listDomains(
-  context: Context,
-  request: HttpRequest,
-  dbService: MongoDbService
-) {
-  let findOptions: Maybe<DomainFindOptions>;
-  if (request.body) {
-    findOptions = request.body.options;
-  }
-  const results = await dbService.getAllDomains(findOptions);
-
-  const responseBody = {
-    numResults: results.length,
-    results: results,
-  };
-
-  context.res = {
-    body: responseBody,
-  };
-}
-
-export async function getDomain(
-  context: Context,
-  request: HttpRequest,
-  dbService: MongoDbService
-) {
-  const domainId: DomainId = request.params.id;
-  if (!validateDomainId(domainId)) {
-    context.res = {
-      status: 400,
-      body: validateDomainId.errors,
-    };
-    return;
-  }
-
-  let findOptions: Maybe<DomainFindOptions>;
-  if (request.body) {
-    findOptions = request.body.options;
-  }
-
-  const result = await dbService.getValidDomain(request.params.id, findOptions);
-
-  const responseBody = {
-    result: result,
-  };
-  context.res = {
-    body: responseBody,
-  };
-}
-
-export async function getSubdomains(
-  context: Context,
-  request: HttpRequest,
-  dbService: MongoDbService
-) {
-  const domainId: DomainId = request.params.id;
-  if (!validateDomainId(domainId)) {
-    context.res = {
-      status: 400,
-      body: validateDomainId.errors,
-    };
-    return;
-  }
-
-  let findOptions: Maybe<DomainFindOptions>;
-  if (request.body) {
-    findOptions = request.body.options;
-  }
-
-  const results = await dbService.getSubdomainsById(
-    request.params.id,
-    findOptions
-  );
-
-  const responseBody = {
-    numResults: results.length,
-    result: results,
-  };
-  context.res = {
-    body: responseBody,
-  };
-}
-
-export async function searchDomainsByOwner(
-  context: Context,
-  request: HttpRequest,
-  dbService: MongoDbService
-) {
-  const ownerAddress: Address = request.params.address;
-  if (!validateBlockchainAddress(ownerAddress)) {
-    context.res = {
-      status: 400,
-      body: validateBlockchainAddress.errors,
-    };
-    return;
-  }
-
-  let findOptions: Maybe<DomainFindOptions>;
-  if (request.body) {
-    findOptions = request.body.options;
-  }
-
-  const results = await dbService.getDomainsByOwner(ownerAddress, findOptions);
-
-  const responseBody = {
-    numResults: results.length,
-    result: results,
-  };
-  context.res = {
-    body: responseBody,
-  };
-}
-
-export async function searchDomainsByName(
-  context: Context,
-  request: HttpRequest,
-  dbService: MongoDbService
-) {
-  const domainName: string = request.params.name;
-
-  let findOptions: Maybe<DomainFindOptions>;
-  if (request.body) {
-    findOptions = request.body.options;
-  }
-
-  const results = await dbService.getDomainsByName(domainName, findOptions);
-
-  const responseBody = {
-    numResults: results.length,
-    result: results,
-  };
-  context.res = {
-    body: responseBody,
-  };
 }

--- a/src/services/domainService.ts
+++ b/src/services/domainService.ts
@@ -1,5 +1,5 @@
 import { Domain, DomainFindOptions, Maybe } from "@zero-tech/data-store-core";
-import { DomainsApiResponse } from "../types";
+import { PaginationResponse } from "../types";
 
 export abstract class DomainService<T> {
   dbService: T;
@@ -8,7 +8,7 @@ export abstract class DomainService<T> {
   }
   abstract listDomains(
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<DomainsApiResponse>;
+  ): Promise<PaginationResponse<Domain>>;
   abstract getDomain(
     id: string,
     findOptions: Maybe<DomainFindOptions>
@@ -16,21 +16,21 @@ export abstract class DomainService<T> {
   abstract getSubdomains(
     id: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<DomainsApiResponse>;
+  ): Promise<PaginationResponse<Domain>>;
   abstract searchDomainsByOwner(
     address: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<DomainsApiResponse>;
+  ): Promise<PaginationResponse<Domain>>;
   abstract searchDomainsByName(
     searchTerm: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<DomainsApiResponse>;
+  ): Promise<PaginationResponse<Domain>>;
   abstract doServiceOperation(
     serviceFn: Function
-  ): Promise<DomainsApiResponse | Domain>;
+  ): Promise<PaginationResponse<Domain> | Domain>;
 
-  domainsToDomainsResponse(domains: Domain[]): DomainsApiResponse {
-    const response: DomainsApiResponse = {
+  domainsToDomainsResponse(domains: Domain[]): PaginationResponse<Domain> {
+    const response: PaginationResponse<Domain> = {
       numResults: domains.length,
       results: domains,
     };

--- a/src/services/legacyDomainService.ts
+++ b/src/services/legacyDomainService.ts
@@ -1,0 +1,177 @@
+import { Context, HttpRequest } from "@azure/functions";
+import {
+  Address,
+  DomainFindOptions,
+  DomainId,
+  Maybe,
+} from "@zero-tech/data-store-core";
+import { MongoDbService } from "@zero-tech/data-store-core/lib/database/mongo/mongoDbService";
+import { MongoClient } from "mongodb";
+import { getConnectedDbClient, getDatabaseService } from "../helpers";
+import { validateAddress, validateDomainId } from "../schemas";
+
+// add try/catch/finally wrapper for 500s
+export async function doServiceOperation(
+  serviceFn: Function,
+  context: Context,
+  request: HttpRequest
+) {
+  let dbClient: Maybe<MongoClient>;
+
+  try {
+    dbClient = await getConnectedDbClient(context);
+    const dbService: MongoDbService = getDatabaseService(dbClient);
+    await serviceFn(context, request, dbService);
+  } catch (e: any) {
+    const error: Error = {
+      name: e.name ?? "Unknown Internal Server Error",
+      message: e.message ?? "An unexpected server error occured.",
+    };
+    context.log(e.name, e.message, e.stack);
+
+    context.res = {
+      status: 500,
+      body: `${error.name} \n ${error.message}`,
+    };
+  } finally {
+    if (dbClient) {
+      await dbClient.close();
+    }
+  }
+}
+
+export async function listDomains(
+  context: Context,
+  request: HttpRequest,
+  dbService: MongoDbService
+) {
+  let findOptions: Maybe<DomainFindOptions>;
+  if (request.body) {
+    findOptions = request.body.options;
+  }
+  const results = await dbService.getAllDomains(findOptions);
+
+  const responseBody = {
+    numResults: results.length,
+    results: results,
+  };
+
+  context.res = {
+    body: responseBody,
+  };
+}
+
+export async function getDomain(
+  context: Context,
+  request: HttpRequest,
+  dbService: MongoDbService
+) {
+  const domainId: DomainId = request.params.id;
+  if (!validateDomainId(domainId)) {
+    context.res = {
+      status: 400,
+      body: validateDomainId.errors,
+    };
+    return;
+  }
+
+  let findOptions: Maybe<DomainFindOptions>;
+  if (request.body) {
+    findOptions = request.body.options;
+  }
+
+  const result = await dbService.getValidDomain(request.params.id, findOptions);
+
+  const responseBody = {
+    result: result,
+  };
+  context.res = {
+    body: responseBody,
+  };
+}
+
+export async function getSubdomains(
+  context: Context,
+  request: HttpRequest,
+  dbService: MongoDbService
+) {
+  const domainId: DomainId = request.params.id;
+  if (!validateDomainId(domainId)) {
+    context.res = {
+      status: 400,
+      body: validateDomainId.errors,
+    };
+    return;
+  }
+
+  let findOptions: Maybe<DomainFindOptions>;
+  if (request.body) {
+    findOptions = request.body.options;
+  }
+
+  const results = await dbService.getSubdomainsById(
+    request.params.id,
+    findOptions
+  );
+
+  const responseBody = {
+    numResults: results.length,
+    result: results,
+  };
+  context.res = {
+    body: responseBody,
+  };
+}
+
+export async function searchDomainsByOwner(
+  context: Context,
+  request: HttpRequest,
+  dbService: MongoDbService
+) {
+  const ownerAddress: Address = request.params.address;
+  if (!validateAddress(ownerAddress)) {
+    context.res = {
+      status: 400,
+      body: validateAddress.errors,
+    };
+    return;
+  }
+
+  let findOptions: Maybe<DomainFindOptions>;
+  if (request.body) {
+    findOptions = request.body.options;
+  }
+
+  const results = await dbService.getDomainsByOwner(ownerAddress, findOptions);
+
+  const responseBody = {
+    numResults: results.length,
+    result: results,
+  };
+  context.res = {
+    body: responseBody,
+  };
+}
+
+export async function searchDomainsByName(
+  context: Context,
+  request: HttpRequest,
+  dbService: MongoDbService
+) {
+  const domainName: string = request.params.name;
+
+  let findOptions: Maybe<DomainFindOptions>;
+  if (request.body) {
+    findOptions = request.body.options;
+  }
+
+  const results = await dbService.getDomainsByName(domainName, findOptions);
+
+  const responseBody = {
+    numResults: results.length,
+    result: results,
+  };
+  context.res = {
+    body: responseBody,
+  };
+}

--- a/src/services/mongoDomainService.ts
+++ b/src/services/mongoDomainService.ts
@@ -1,7 +1,7 @@
 import { Domain, DomainFindOptions, Maybe } from "@zero-tech/data-store-core";
 import { MongoDbService } from "@zero-tech/data-store-core/lib/database/mongo/mongoDbService";
 import { MongoClient } from "mongodb";
-import { DomainsApiResponse } from "../types";
+import { PaginationResponse } from "../types";
 import { DomainService } from "./domainService";
 
 //Remake to MONGODomainService implemented with mongo
@@ -15,7 +15,7 @@ export class MongoDomainService extends DomainService<MongoDbService> {
 
   async listDomains(
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<DomainsApiResponse> {
+  ): Promise<PaginationResponse<Domain>> {
     const domains: Domain[] = await this.doServiceOperation(async () => {
       return await this.dbService.getAllDomains(findOptions);
     });
@@ -35,7 +35,7 @@ export class MongoDomainService extends DomainService<MongoDbService> {
   async getSubdomains(
     id: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<DomainsApiResponse> {
+  ): Promise<PaginationResponse<Domain>> {
     const domains: Domain[] = await this.doServiceOperation(async () => {
       return await this.dbService.getSubdomainsById(id, findOptions);
     });
@@ -45,7 +45,7 @@ export class MongoDomainService extends DomainService<MongoDbService> {
   async searchDomainsByOwner(
     address: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<DomainsApiResponse> {
+  ): Promise<PaginationResponse<Domain>> {
     const domains: Domain[] = await this.doServiceOperation(async () => {
       return await this.dbService.getDomainsByOwner(address, findOptions);
     });
@@ -55,7 +55,7 @@ export class MongoDomainService extends DomainService<MongoDbService> {
   async searchDomainsByName(
     searchTerm: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<DomainsApiResponse> {
+  ): Promise<PaginationResponse<Domain>> {
     const domains: Domain[] = await this.doServiceOperation(async () => {
       return await this.dbService.getDomainsByName(searchTerm, findOptions);
     });

--- a/src/services/mongoDomainService.ts
+++ b/src/services/mongoDomainService.ts
@@ -1,0 +1,80 @@
+import { Domain, DomainFindOptions, Maybe } from "@zero-tech/data-store-core";
+import { MongoDbService } from "@zero-tech/data-store-core/lib/database/mongo/mongoDbService";
+import { MongoClient } from "mongodb";
+import { DomainsApiResponse } from "../types";
+import { DomainService } from "./domainService";
+
+//Remake to MONGODomainService implemented with mongo
+export class MongoDomainService extends DomainService<MongoDbService> {
+  dbClient: MongoClient;
+
+  constructor(client: MongoClient, service: MongoDbService) {
+    super(service);
+    this.dbClient = client;
+  }
+
+  async listDomains(
+    findOptions: Maybe<DomainFindOptions>
+  ): Promise<DomainsApiResponse> {
+    const domains: Domain[] = await this.doServiceOperation(async () => {
+      return await this.dbService.getAllDomains(findOptions);
+    });
+    return this.domainsToDomainsResponse(domains);
+  }
+
+  async getDomain(
+    id: string,
+    findOptions: Maybe<DomainFindOptions>
+  ): Promise<Domain> {
+    const domain: Domain = await this.doServiceOperation(async () => {
+      return await this.dbService.getValidDomain(id, findOptions);
+    });
+    return domain;
+  }
+
+  async getSubdomains(
+    id: string,
+    findOptions: Maybe<DomainFindOptions>
+  ): Promise<DomainsApiResponse> {
+    const domains: Domain[] = await this.doServiceOperation(async () => {
+      return await this.dbService.getSubdomainsById(id, findOptions);
+    });
+    return this.domainsToDomainsResponse(domains);
+  }
+
+  async searchDomainsByOwner(
+    address: string,
+    findOptions: Maybe<DomainFindOptions>
+  ): Promise<DomainsApiResponse> {
+    const domains: Domain[] = await this.doServiceOperation(async () => {
+      return await this.dbService.getDomainsByOwner(address, findOptions);
+    });
+    return this.domainsToDomainsResponse(domains);
+  }
+
+  async searchDomainsByName(
+    searchTerm: string,
+    findOptions: Maybe<DomainFindOptions>
+  ): Promise<DomainsApiResponse> {
+    const domains: Domain[] = await this.doServiceOperation(async () => {
+      return await this.dbService.getDomainsByName(searchTerm, findOptions);
+    });
+    return this.domainsToDomainsResponse(domains);
+  }
+
+  async doServiceOperation(serviceFn: Function): Promise<any> {
+    try {
+      return await serviceFn();
+    } catch (e: any) {
+      const error: Error = {
+        name: e.name ?? "Unknown Internal Server Error",
+        message: e.message ?? "An unexpected server error occured.",
+      };
+      throw error;
+    } finally {
+      if (this.dbClient) {
+        await this.dbClient.close();
+      }
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,8 @@ export interface PaginationResponse<T> {
 }
 
 export enum DomainSortDirection {
-  descending = 0,
-  ascending = 1,
+  desc = 0,
+  asc = 1,
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
 import { Domain } from "@zero-tech/data-store-core";
 
-export interface DomainsApiResponse {
-  numResults?: number;
-  results: Domain[];
+export interface PaginationResponse<T> {
+  numResults: number;
+  results: T[];
 }
 
 export enum DomainSortDirection {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,36 @@
+import { Domain } from "@zero-tech/data-store-core";
+
+export interface DomainsApiResponse {
+  numResults?: number;
+  results: Domain[];
+}
+
+export enum DomainSortDirection {
+  descending = 0,
+  ascending = 1,
+}
+
+/**
+ * If this ever fails to compile, initialize the missing variable with a default value
+ */
+export const domainReflectionSchema: Domain = {
+  domainId: "",
+  isRoot: false,
+  children: [],
+  history: {
+    transfers: [],
+  },
+  label: undefined,
+  name: undefined,
+  parent: undefined,
+  labelHash: undefined,
+  minter: undefined,
+  owner: undefined,
+  metadataUri: undefined,
+  royaltyAmount: undefined,
+  locked: undefined,
+  lockedBy: undefined,
+  created: undefined,
+  registrar: undefined,
+  isValid: false,
+};


### PR DESCRIPTION
Modifying all the data store methods to use query string parameters and GET requests, renamed all the old methods to "Legacy" and made the new ones under "v1"