### PR TITLE
Adding Pagination Response to Data Store API V1 Methods

### DIFF
--- a/domain-get-subdomains/index.ts
+++ b/domain-get-subdomains/index.ts
@@ -1,10 +1,12 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import { DomainId } from "@zero-tech/data-store-core";
+import { Domain, DomainId } from "@zero-tech/data-store-core";
 import { getMongoDomainService } from "../src/helpers";
 import { getDomainFindOptionsFromQuery } from "../src/helpers/domainFindOptionsHelper";
 import { validateDomainId } from "../src/schemas";
 import { createHTTPResponse } from "../src/helpers/createHTTPResponse";
 import { createErrorResponse } from "../src/helpers/createErrorResponse";
+import { generatePaginationResponse } from "../src/helpers/paginationHelper";
+import * as constants from "../src/constants";
 
 const httpTrigger: AzureFunction = async function (
   context: Context,
@@ -18,14 +20,21 @@ const httpTrigger: AzureFunction = async function (
       return;
     }
 
-    const findOptions = getDomainFindOptionsFromQuery(req);
+    const findOptions = getDomainFindOptionsFromQuery(req, true);
     const domainService = await getMongoDomainService(context.log);
     const response = await domainService.getSubdomains(
       req.params.id,
       findOptions
     );
+    const paginationResponse = generatePaginationResponse<Domain>(
+      response,
+      findOptions.skip ?? constants.defaultSkip,
+      findOptions.limit ?? constants.defaultLimit,
+      req.query,
+      constants.routes.v1.getSubdomainsById + domainId
+    );
     context.res = {
-      body: response,
+      body: paginationResponse,
     };
   } catch (err) {
     context.log.error(

--- a/domain-get/index.ts
+++ b/domain-get/index.ts
@@ -1,5 +1,5 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import { DomainId } from "@zero-tech/data-store-core";
+import { Domain, DomainId } from "@zero-tech/data-store-core";
 import { getMongoDomainService } from "../src/helpers";
 import { createErrorResponse } from "../src/helpers/createErrorResponse";
 import { createHTTPResponse } from "../src/helpers/createHTTPResponse";
@@ -20,9 +20,13 @@ const httpTrigger: AzureFunction = async function (
     let findOptions = getDomainFindOptionsFromQuery(req);
     const domainService = await getMongoDomainService(context.log);
     const response = await domainService.getDomain(req.params.id, findOptions);
-    context.res = {
-      body: response,
-    };
+    if (response) {
+      context.res = {
+        body: response,
+      };
+    } else {
+      context.res = createHTTPResponse(204);
+    }
   } catch (err) {
     context.log.error("GET Domain, error encountered: ", JSON.stringify(err));
     context.res = createErrorResponse(err, context);

--- a/domain-search-by-name/index.ts
+++ b/domain-search-by-name/index.ts
@@ -1,7 +1,10 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
+import { Domain } from "@zero-tech/data-store-core";
 import { getMongoDomainService } from "../src/helpers";
 import { createErrorResponse } from "../src/helpers/createErrorResponse";
 import { getDomainFindOptionsFromQuery } from "../src/helpers/domainFindOptionsHelper";
+import { generatePaginationResponse } from "../src/helpers/paginationHelper";
+import * as constants from "../src/constants";
 
 const httpTrigger: AzureFunction = async function (
   context: Context,
@@ -13,14 +16,21 @@ const httpTrigger: AzureFunction = async function (
     );
     const domainName: string = req.params.name;
 
-    let findOptions = getDomainFindOptionsFromQuery(req);
+    let findOptions = getDomainFindOptionsFromQuery(req, true);
     const domainService = await getMongoDomainService(context.log);
     const response = await domainService.searchDomainsByName(
       domainName,
       findOptions
     );
+    const paginationResponse = generatePaginationResponse<Domain>(
+      response,
+      findOptions.skip ?? constants.defaultSkip,
+      findOptions.limit ?? constants.defaultLimit,
+      req.query,
+      constants.routes.v1.searchDomainsByName + domainName
+    );
     context.res = {
-      body: response,
+      body: paginationResponse,
     };
   } catch (err) {
     context.log.error(

--- a/domain-search-by-owner/index.ts
+++ b/domain-search-by-owner/index.ts
@@ -1,10 +1,12 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
-import { Address } from "@zero-tech/data-store-core";
+import { Address, Domain } from "@zero-tech/data-store-core";
 import { getMongoDomainService } from "../src/helpers";
 import { createErrorResponse } from "../src/helpers/createErrorResponse";
 import { createHTTPResponse } from "../src/helpers/createHTTPResponse";
 import { getDomainFindOptionsFromQuery } from "../src/helpers/domainFindOptionsHelper";
 import { validateAddress } from "../src/schemas";
+import { generatePaginationResponse } from "../src/helpers/paginationHelper";
+import * as constants from "../src/constants";
 
 const httpTrigger: AzureFunction = async function (
   context: Context,
@@ -20,14 +22,22 @@ const httpTrigger: AzureFunction = async function (
       return;
     }
 
-    let findOptions = getDomainFindOptionsFromQuery(req);
+    let findOptions = getDomainFindOptionsFromQuery(req, true);
     const domainService = await getMongoDomainService(context.log);
     const response = await domainService.searchDomainsByOwner(
       ownerAddress,
       findOptions
     );
+
+    const paginationResponse = generatePaginationResponse<Domain>(
+      response,
+      findOptions.skip ?? constants.defaultSkip,
+      findOptions.limit ?? constants.defaultLimit,
+      req.query,
+      constants.routes.v1.searchDomainsByOwner + ownerAddress
+    );
     context.res = {
-      body: response,
+      body: paginationResponse,
     };
   } catch (err) {
     context.log.error(

--- a/domains/index.ts
+++ b/domains/index.ts
@@ -1,19 +1,28 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
+import { Domain } from "@zero-tech/data-store-core";
 import { getMongoDomainService } from "../src/helpers";
 import { createErrorResponse } from "../src/helpers/createErrorResponse";
 import { getDomainFindOptionsFromQuery } from "../src/helpers/domainFindOptionsHelper";
-
+import { generatePaginationResponse } from "../src/helpers/paginationHelper";
+import * as constants from "../src/constants";
 const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest
 ): Promise<void> {
   try {
     context.log("GET Domains: HTTP trigger function processed a request.");
-    let findOptions = getDomainFindOptionsFromQuery(req);
+    let findOptions = getDomainFindOptionsFromQuery(req, true);
     const domainService = await getMongoDomainService(context.log);
     const response = await domainService.listDomains(findOptions);
+    const paginationResponse = generatePaginationResponse<Domain>(
+      response,
+      findOptions.skip ?? constants.defaultSkip,
+      findOptions.limit ?? constants.defaultLimit,
+      req.query,
+      constants.routes.v1.listDomains
+    );
     context.res = {
-      body: response,
+      body: paginationResponse,
     };
   } catch (err) {
     context.log.error("GET Domains, error encountered: ", JSON.stringify(err));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,16 @@
+import { Sort } from "./types";
+
+export const defaultLimit = 100;
+export const defaultSkip = 0;
+export const defaultProjection = ["domainid", "owner", "name"];
+export const defaultSort = ["label"];
+export const defaultSortDirection: Sort[] = [-1];
+export const routes = {
+  v1: {
+    listDomains: "v1/domains/list",
+    searchDomainsByName: "v1/domains/search/name/",
+    searchDomainsByOwner: "v1/domains/search/owner/",
+    getSubdomainsById: "v1/domains/subdomains/",
+    getDomainsById: "v1/domains/get/",
+  },
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,8 +2,7 @@ import { Sort } from "./types";
 
 export const defaultLimit = 100;
 export const defaultSkip = 0;
-export const defaultProjection = ["domainid", "owner", "name"];
-export const defaultSort = ["label"];
+export const defaultSort = ["name"];
 export const defaultSortDirection: Sort[] = [-1];
 export const routes = {
   v1: {

--- a/src/helpers/createHTTPResponse.ts
+++ b/src/helpers/createHTTPResponse.ts
@@ -1,7 +1,14 @@
-export function createHTTPResponse(statusCode: number, body: unknown): Object {
-  const response = {
-    status: statusCode,
-    body: body,
-  };
+export function createHTTPResponse(statusCode: number, body?: unknown): Object {
+  let response;
+  if (body) {
+    response = {
+      status: statusCode,
+      body: body,
+    };
+  } else {
+    response = {
+      statusCode: statusCode,
+    };
+  }
   return response;
 }

--- a/src/helpers/domainFindOptionsHelper.ts
+++ b/src/helpers/domainFindOptionsHelper.ts
@@ -20,7 +20,7 @@ interface DynamicObject<T> {
  */
 export function getDomainFindOptionsFromQuery(
   req: HttpRequest,
-  pageable?: boolean
+  pageable = false
 ) {
   //Get variables to project, matching the case insensitive names to case sensitive object names
   const projection = createProjection(req);

--- a/src/helpers/domainFindOptionsHelper.ts
+++ b/src/helpers/domainFindOptionsHelper.ts
@@ -10,9 +10,6 @@ interface DynamicObject<T> {
   [key: string]: T;
 }
 
-const defaultSort = ["label"];
-const defaultSortDirection: Sort[] = [-1];
-
 /*
  * Generates a DomainFindOptions object based on query string parameters
  * @param req - An HttpRequest

--- a/src/helpers/paginationHelper.ts
+++ b/src/helpers/paginationHelper.ts
@@ -37,9 +37,7 @@ export function generatePaginationResponse<T>(
   if (results.length > 1) {
     results = results.slice(0, -1);
   }
-  const pageNumber = Math.abs(
-    limit > 0 && skip > 0 && skip > limit ? Math.ceil(skip / limit) : 1
-  );
+  const pageNumber = limit ? Math.ceil(skip / limit) + 1 : 1;
   const response: PaginationResponse<T> = {
     results: results,
     pagination: {

--- a/src/helpers/paginationHelper.ts
+++ b/src/helpers/paginationHelper.ts
@@ -1,0 +1,128 @@
+import { HttpRequestQuery } from "@azure/functions";
+import { DomainFindOptions } from "@zero-tech/data-store-core";
+import { PaginationResponse } from "../types";
+
+/**
+ * Transforms an array of objects into a paginated response payload
+ * @param results - An array of objects to be included as the primary resposne
+ * @param limit - The upper limit of returnable objects from the query
+ * @param skip - The amount of objectst that were skipped in the query
+ * @param query - The query string parameters used to generate the query
+ * @param path - The Path of the function that was called
+ * @returns
+ */
+export function generatePaginationResponse<T>(
+  results: T[],
+  skip: number,
+  limit: number,
+  query: HttpRequestQuery,
+  path: string
+): PaginationResponse<T> {
+  //Decrement the limit by one, as it was increased by one to determine next page status
+  if (limit > 0) limit -= 1;
+  const next = generateNextLink(
+    new Map(Object.entries(query)),
+    limit,
+    results.length,
+    path
+  );
+  const previous = generatePreviousLink(
+    new Map(Object.entries(query)),
+    skip,
+    limit,
+    path
+  );
+  //Remove last result, as it was only included to determine next page status
+  if (results.length > 1) {
+    results = results.slice(0, -1);
+  }
+  const response: PaginationResponse<T> = {
+    results: results,
+    pagination: {
+      //Default to 1 as minimum page, otherwise round up to the nearest page
+      pageNumber: Math.abs(
+        limit > 0 && skip > 0 && skip > limit ? Math.ceil(skip / limit) : 1
+      ),
+      pageSize: limit,
+      pageResults: results.length,
+      links: {
+        next: next,
+        previous: previous,
+      },
+    },
+  };
+  return response;
+}
+
+/**
+ * Enables a DomainFindOptions to be pageable by expanding the limit for 1 (So that the status of the next page can be determined)
+ * @param findOptions  - A DomainFindOptions object used to determine the mongo query parameters
+ * @returns - A DomainFindOptions with the limit increased by 1, unless there is no limit or the limit is already at its maximum value
+ */
+export function generatePageableFindOptions(
+  findOptions: DomainFindOptions
+): DomainFindOptions {
+  if (
+    isNaN(findOptions?.limit ?? NaN) ||
+    !findOptions.limit ||
+    findOptions.limit == Number.MAX_VALUE
+  ) {
+    return findOptions;
+  }
+  findOptions.limit += 1;
+  return findOptions;
+}
+
+function generateNextLink(
+  query: Map<string, string>,
+  limit: number,
+  numResults: number,
+  path: string
+): string {
+  //Check for status of next page
+  if (numResults >= limit) {
+    return path + generateQueryString(query, limit, true);
+  }
+  return "";
+}
+
+function generatePreviousLink(
+  query: Map<string, string>,
+  skip: number,
+  limit: number,
+  path: string
+): string {
+  //Check for status of previous page
+  if (skip >= limit) {
+    return path + generateQueryString(query, limit, false);
+  }
+  return "";
+}
+
+function generateQueryString(
+  query: Map<string, string>,
+  reqLimit: number,
+  next: boolean
+): string {
+  const qSkip = query.get("skip") ?? 0;
+  query.delete("limit");
+  query.delete("skip");
+  let skip = isNaN(+qSkip) ? 0 : +qSkip;
+  if (next) {
+    //Generate next page skip value
+    skip = skip + reqLimit;
+  } else if (skip >= reqLimit) {
+    //Generate previous page skip value
+    skip = skip - reqLimit;
+  } else {
+    //Previous page defaulted to beginning
+    skip = 0;
+  }
+  let queryString = `?limit=${reqLimit}&skip=${skip}`;
+
+  //Populate the remaining query string parameters
+  for (let [key, value] of query) {
+    queryString += `&${key}=${value}`;
+  }
+  return queryString;
+}

--- a/src/services/domainService.ts
+++ b/src/services/domainService.ts
@@ -1,5 +1,4 @@
 import { Domain, DomainFindOptions, Maybe } from "@zero-tech/data-store-core";
-import { PaginationResponse } from "../types";
 
 export abstract class DomainService<T> {
   dbService: T;
@@ -8,7 +7,7 @@ export abstract class DomainService<T> {
   }
   abstract listDomains(
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<PaginationResponse<Domain>>;
+  ): Promise<Domain[]>;
   abstract getDomain(
     id: string,
     findOptions: Maybe<DomainFindOptions>
@@ -16,24 +15,14 @@ export abstract class DomainService<T> {
   abstract getSubdomains(
     id: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<PaginationResponse<Domain>>;
+  ): Promise<Domain[]>;
   abstract searchDomainsByOwner(
     address: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<PaginationResponse<Domain>>;
+  ): Promise<Domain[]>;
   abstract searchDomainsByName(
     searchTerm: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<PaginationResponse<Domain>>;
-  abstract doServiceOperation(
-    serviceFn: Function
-  ): Promise<PaginationResponse<Domain> | Domain>;
-
-  domainsToDomainsResponse(domains: Domain[]): PaginationResponse<Domain> {
-    const response: PaginationResponse<Domain> = {
-      numResults: domains.length,
-      results: domains,
-    };
-    return response;
-  }
+  ): Promise<Domain[]>;
+  abstract doServiceOperation(serviceFn: Function): Promise<Domain[] | Domain>;
 }

--- a/src/services/mongoDomainService.ts
+++ b/src/services/mongoDomainService.ts
@@ -1,10 +1,9 @@
 import { Domain, DomainFindOptions, Maybe } from "@zero-tech/data-store-core";
 import { MongoDbService } from "@zero-tech/data-store-core/lib/database/mongo/mongoDbService";
 import { MongoClient } from "mongodb";
-import { Logger, PaginationResponse } from "../types";
+import { Logger } from "../types";
 import { DomainService } from "./domainService";
 
-//Remake to MONGODomainService implemented with mongo
 export class MongoDomainService extends DomainService<MongoDbService> {
   dbClient: MongoClient;
   logger: Logger;
@@ -14,14 +13,12 @@ export class MongoDomainService extends DomainService<MongoDbService> {
     this.logger = logger;
   }
 
-  async listDomains(
-    findOptions: Maybe<DomainFindOptions>
-  ): Promise<PaginationResponse<Domain>> {
+  async listDomains(findOptions: Maybe<DomainFindOptions>): Promise<Domain[]> {
     const domains: Domain[] = await this.doServiceOperation(async () => {
       this.logger(`Listing all domains`, JSON.stringify(findOptions));
       return await this.dbService.getAllDomains(findOptions);
     });
-    return this.domainsToDomainsResponse(domains);
+    return domains;
   }
 
   async getDomain(
@@ -38,18 +35,18 @@ export class MongoDomainService extends DomainService<MongoDbService> {
   async getSubdomains(
     id: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<PaginationResponse<Domain>> {
+  ): Promise<Domain[]> {
     const domains: Domain[] = await this.doServiceOperation(async () => {
       this.logger(`Getting subdomains for ${id}`, JSON.stringify(findOptions));
       return await this.dbService.getSubdomainsById(id, findOptions);
     });
-    return this.domainsToDomainsResponse(domains);
+    return domains;
   }
 
   async searchDomainsByOwner(
     address: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<PaginationResponse<Domain>> {
+  ): Promise<Domain[]> {
     const domains: Domain[] = await this.doServiceOperation(async () => {
       this.logger(
         `Searching domains by owner ${address}`,
@@ -57,13 +54,13 @@ export class MongoDomainService extends DomainService<MongoDbService> {
       );
       return await this.dbService.getDomainsByOwner(address, findOptions);
     });
-    return this.domainsToDomainsResponse(domains);
+    return domains;
   }
 
   async searchDomainsByName(
     searchTerm: string,
     findOptions: Maybe<DomainFindOptions>
-  ): Promise<PaginationResponse<Domain>> {
+  ): Promise<Domain[]> {
     const domains: Domain[] = await this.doServiceOperation(async () => {
       this.logger(
         `Searching domains by name ${searchTerm}`,
@@ -71,7 +68,7 @@ export class MongoDomainService extends DomainService<MongoDbService> {
       );
       return await this.dbService.getDomainsByName(searchTerm, findOptions);
     });
-    return this.domainsToDomainsResponse(domains);
+    return domains;
   }
 
   async doServiceOperation(serviceFn: Function): Promise<any> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,18 @@
 import { Domain } from "@zero-tech/data-store-core";
 
+export type Sort = -1 | 1;
+export type Projection = 0 | 1;
 export interface PaginationResponse<T> {
-  numResults: number;
   results: T[];
+  pagination: {
+    pageNumber: number;
+    pageSize: number;
+    pageResults: number;
+    links: {
+      next: string;
+      previous: string;
+    };
+  };
 }
 
 export enum DomainSortDirection {


### PR DESCRIPTION
Adding a pagination response to the v1 methods, the response follows this format:

```
{
  "results": [
   ...Results go here...
  ],
  "pagination": {
    "pageNumber": 1,
    "pageSize": 1,
    "pageResults": 1,
    "links": {
      "next": "v1/domains/list?limit=1&skip=2&sortDirection=asc,asc&fields=owner,label&projectionN=true&sort=owner,label",
      "previous": "v1/domains/list?limit=1&skip=0&sortDirection=asc,asc&fields=owner,label&projectionN=true&sort=owner,label"
    }
  }
}
```

Any query string parameters will try to be preserved when formatting the next/previous links. As discussed, if reaching the last page the links result will simply be an empty string.