### PR TITLE
Adding support for activeBids

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,19 +1,12 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": [
-    "@typescript-eslint",
-    "prettier"
-  ],
+  "plugins": ["@typescript-eslint", "prettier"],
   "overrides": [
     {
-      "files": [
-        "*.ts"
-      ],
+      "files": ["*.ts"],
       "parserOptions": {
-        "project": [
-          "./tsconfig.json"
-        ]
+        "project": ["./tsconfig.json"]
       }
     }
   ],
@@ -29,8 +22,6 @@
         "endOfLine": "auto"
       }
     ],
-    "@typescript-eslint/no-floating-promises": [
-      "error"
-    ]
+    "@typescript-eslint/no-floating-promises": ["error"]
   }
 }

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -16,4 +16,4 @@ jobs:
             ${{ github.actor }} opened a PR for review:
 
             ${{ github.event.pull_request.title }}  
-            ${{ github.event.pull_request._links.html.href }}      
+            ${{ github.event.pull_request._links.html.href }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "data-store-api",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@azure/functions": "3.0.0",
         "@ethersproject/constants": "5.7.0",
-        "@zero-tech/data-store-core": "0.4.3",
+        "@zero-tech/data-store-core": "0.4.5",
         "ajv": "8.11.0",
         "env-var": "7.1.1"
       },
@@ -2715,15 +2715,15 @@
       }
     },
     "node_modules/@zero-tech/data-store-core": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@zero-tech/data-store-core/-/data-store-core-0.4.3.tgz",
-      "integrity": "sha512-hNLGi4Qvzu1DKsKvb974XaztIUysYYLDoLtUk28KYomIdphUNL5k5lM5Di8/n51WyfoJuj9TQ+To/xgQdJ+Caw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@zero-tech/data-store-core/-/data-store-core-0.4.5.tgz",
+      "integrity": "sha512-A+NAx+TGy2uURx0N09eCe6s2FtlS9TQ/0rgXVybbkOBgTLc0RAEvQEJTM1Gb6dQQm1f8bGwlnG27zbcLoGw9jg==",
       "dependencies": {
         "@azure/event-hubs": "5.7.0",
         "@azure/eventhubs-checkpointstore-blob": "1.0.1",
         "@azure/storage-blob": "12.9.0",
         "@zero-tech/zero-contracts": "0.0.7",
-        "@zero-tech/zns-message-schemas": "1.5.1",
+        "@zero-tech/zns-message-schemas": "1.5.5",
         "ajv": "7.2.4",
         "applicationinsights": "^2.3.3",
         "cors": "2.8.5",
@@ -2770,9 +2770,9 @@
       "integrity": "sha512-0B192LZOF8X33v2FUsfVcVSQPOoElHT/16Z5KB80Zp2A3IvFnzfikhUKwTIwzZQCl/fvJz2OV5gS7l7oDcPAkw=="
     },
     "node_modules/@zero-tech/zns-message-schemas": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zns-message-schemas/-/zns-message-schemas-1.5.1.tgz",
-      "integrity": "sha512-7G4RShu+/G/WF9+QbDAX2FmC7f71y3PlYg1Jx+VKecxgeYLU0+tKD4VTZmt9klcENTbNBlFLsjMfatmNRuzHTQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zns-message-schemas/-/zns-message-schemas-1.5.5.tgz",
+      "integrity": "sha512-Tx2Z87xJTb8PYFGQxrRFRMjs9Sree5f95/ywLu56dXgWTXk1kV3MiU0l9TboteKp2/R6001UvMDPloWbqhjaPg=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -11188,15 +11188,15 @@
       }
     },
     "@zero-tech/data-store-core": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@zero-tech/data-store-core/-/data-store-core-0.4.3.tgz",
-      "integrity": "sha512-hNLGi4Qvzu1DKsKvb974XaztIUysYYLDoLtUk28KYomIdphUNL5k5lM5Di8/n51WyfoJuj9TQ+To/xgQdJ+Caw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@zero-tech/data-store-core/-/data-store-core-0.4.5.tgz",
+      "integrity": "sha512-A+NAx+TGy2uURx0N09eCe6s2FtlS9TQ/0rgXVybbkOBgTLc0RAEvQEJTM1Gb6dQQm1f8bGwlnG27zbcLoGw9jg==",
       "requires": {
         "@azure/event-hubs": "5.7.0",
         "@azure/eventhubs-checkpointstore-blob": "1.0.1",
         "@azure/storage-blob": "12.9.0",
         "@zero-tech/zero-contracts": "0.0.7",
-        "@zero-tech/zns-message-schemas": "1.5.1",
+        "@zero-tech/zns-message-schemas": "1.5.5",
         "ajv": "7.2.4",
         "applicationinsights": "^2.3.3",
         "cors": "2.8.5",
@@ -11236,9 +11236,9 @@
       "integrity": "sha512-0B192LZOF8X33v2FUsfVcVSQPOoElHT/16Z5KB80Zp2A3IvFnzfikhUKwTIwzZQCl/fvJz2OV5gS7l7oDcPAkw=="
     },
     "@zero-tech/zns-message-schemas": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@zero-tech/zns-message-schemas/-/zns-message-schemas-1.5.1.tgz",
-      "integrity": "sha512-7G4RShu+/G/WF9+QbDAX2FmC7f71y3PlYg1Jx+VKecxgeYLU0+tKD4VTZmt9klcENTbNBlFLsjMfatmNRuzHTQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@zero-tech/zns-message-schemas/-/zns-message-schemas-1.5.5.tgz",
+      "integrity": "sha512-Tx2Z87xJTb8PYFGQxrRFRMjs9Sree5f95/ywLu56dXgWTXk1kV3MiU0l9TboteKp2/R6001UvMDPloWbqhjaPg=="
     },
     "accepts": {
       "version": "1.3.8",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@azure/functions": "3.0.0",
     "@ethersproject/constants": "5.7.0",
-    "@zero-tech/data-store-core": "0.4.3",
+    "@zero-tech/data-store-core": "0.4.5",
     "ajv": "8.11.0",
     "env-var": "7.1.1"
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -82,4 +82,7 @@ export const mappingSortProps: MappingSortProps = {
   history: {
     history: -1,
   },
+  activeBids: {
+    activeBids: -1,
+  },
 };

--- a/src/services/domainService.ts
+++ b/src/services/domainService.ts
@@ -67,6 +67,7 @@ export abstract class DomainService<T> {
       created: domain.created,
       children: domain.children,
       history: domain.history,
+      activeBids: domain.activeBids,
       groupId: domain.groupId.value,
       groupFileIndex: domain.groupFileIndex,
       buyNow: domain.buyNow.value,

--- a/src/services/legacyDomainService.ts
+++ b/src/services/legacyDomainService.ts
@@ -106,6 +106,9 @@ export async function getSubdomains(
   if (request.body) {
     findOptions = request.body.options;
   }
+  if (!findOptions) {
+    findOptions = {};
+  }
   context.log(
     `Getting subdomains for ${domainId}`,
     JSON.stringify(findOptions)

--- a/src/services/mongoDomainService.ts
+++ b/src/services/mongoDomainService.ts
@@ -47,7 +47,7 @@ export class MongoDomainService extends DomainService<MongoDbService> {
 
   async getSubdomains(
     id: string,
-    findOptions: Maybe<DomainFindOptions>
+    findOptions: DomainFindOptions
   ): Promise<DomainDto[]> {
     const domains: ValidDomain[] = await this.doServiceOperation(async () => {
       this.logger(`Getting subdomains for ${id}`, JSON.stringify(findOptions));

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,10 @@ import {
   UInt256,
 } from "@zero-tech/data-store-core";
 import { Time } from "@zero-tech/data-store-core/lib/shared/helpers/time";
-import { History } from "@zero-tech/data-store-core/lib/shared/types/history";
+import {
+  BidPlacedEvent,
+  History,
+} from "@zero-tech/data-store-core/lib/shared/types/history";
 
 export type Projection = 0 | 1;
 export interface PaginationResponse<T> {
@@ -56,6 +59,7 @@ export interface DomainDto {
   created: Time;
   children: DomainId[];
   history: History[];
+  activeBids: BidPlacedEvent[];
   groupId: UInt256;
   groupFileIndex: UInt256;
   buyNow: BuyNow;


### PR DESCRIPTION
Adding support for ActiveBids in datastore API. Additionally, CancelledBids and BidPlaced items should appear in the domain history.

I decided against adding additional sort options, because as activeBids are an array of items its not possible to sort activebids as discussed in the ticket